### PR TITLE
Support GNOME Shell 3.38.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -33,8 +33,8 @@ function init() {
         style_class: 'panel-button',
         reactive: true,
         can_focus: true,
-        x_fill: true,
-        y_fill: false,
+        x_expand: true,
+        y_expand: false,
         track_hover: true
     });
 


### PR DESCRIPTION
GNOME Shell 3.38 replaced `x_fill` and `y_fill` with `x_expand` and
`y_expand` in properties of `St.Bin`.

Fixed https://github.com/biji/simplenetspeed/issues/19.