### PR TITLE
Remove empty space from the label

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,78 +1,58 @@
 .simplenetspeed-label {
-    width: 7em;
-    text-align: right;
     margin-left: 1px;
     margin-right: 2px;
     font-size: 1em;
 }
 
 .simplenetspeed-label-w {
-    width: 11em;
-    text-align: right;
     margin-left: 1px;
     margin-right: 1px;
     font-size: 1em;
 }
 
 .simplenetspeed-label-1 {
-    width: 7em;
-    text-align: right;
     margin-left: 1px;
     margin-right: 2px;
     font-size: .65em;
 }
 
 .simplenetspeed-label-w-1 {
-    width: 11em;
-    text-align: right;
     margin-left: 1px;
     margin-right: 1px;
     font-size: .65em;
 }
 
 .simplenetspeed-label-2 {
-    width: 7em;
-    text-align: right;
     margin-left: 1px;
     margin-right: 2px;
     font-size: .7em;
 }
 
 .simplenetspeed-label-w-2 {
-    width: 11em;
-    text-align: right;
     margin-left: 1px;
     margin-right: 1px;
     font-size: .7em;
 }
 
 .simplenetspeed-label-3 {
-    width: 7em;
-    text-align: right;
     margin-left: 1px;
     margin-right: 2px;
     font-size: .9em;
 }
 
 .simplenetspeed-label-w-3 {
-    width: 11em;
-    text-align: right;
     margin-left: 1px;
     margin-right: 1px;
     font-size: .9em;
 }
 
 .simplenetspeed-label-4 {
-    width: 7em;
-    text-align: right;
     margin-left: 1px;
     margin-right: 2px;
     font-size: 1.1em;
 }
 
 .simplenetspeed-label-w-4 {
-    width: 11em;
-    text-align: right;
     margin-left: 1px;
     margin-right: 1px;
     font-size: 1.1em;


### PR DESCRIPTION
**Problem**: Unnecessary Whitespace on the left of the label

**Cause** :In the stylesheet.css file, the classes have width and text-align
attributes. These attributes are not required, because the set_text()
function automatically resizes the label according to the text.
    
**Justification for change** :This was causing unnecessary space to appear on the left of the label.
If it was meant for disambiguation of labels, it is not required: because all labels already have icon prefix, viz Sigma,
down-arrow, up-arrow etc.