### PR TITLE
Add support for Gnome 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,9 +10,10 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/biji/simplenetspeed",
   "uuid": "simplenetspeed@biji.extension",
-  "version": 29
+  "version": 30
 }


### PR DESCRIPTION
Since Ubuntu 23.04 migration and Gnome 44, extension is not starting anymore.

I just added the gnome 44 and increment the version number, no more tests.

It just works actually, extension is starting and network is monitored correctly.