### PR TITLE
Update metadata.json shell version to 46

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Simply showing network speed. Left click to change modes:\n\n1. Total net speed in bits per second\n2. Total net speed in Bytes per second\n3. Up & down speed in bits per second\n4. Up & down speed in Bytes per second\n5. Total of downloaded in Bytes (Right click to reset counter)\n\nMiddle click to change font size",
   "name": "Simple net speed",
   "shell-version": [
-    "45"
+    "46"
   ],
   "url": "https://github.com/biji/simplenetspeed",
   "uuid": "simplenetspeed@biji.extension",


### PR DESCRIPTION
already tested it working when `gnome-shell --version` return `GNOME Shell 46.0`