### PR TITLE
Add support for GNOME 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,9 +5,10 @@
   "shell-version": [
     "47",
     "48",
-    "49"
+    "49",
+    "50"
   ],
   "url": "https://github.com/biji/simplenetspeed",
   "uuid": "simplenetspeed@biji.extension",
-  "version": 34
+  "version": 35
 }


### PR DESCRIPTION
## Description
This PR bumps the supported shell version to include GNOME 50, allowing users to install and run the extension natively on the latest release. The GNOME 50 breaking changes does not affect the API used by simplenetspeed

### Changes included:
1. Appended "50" to the shell-version array in metadata.json.

### Testing:
✅ Verified installation and core functionality (speed display, left/right/middle click actions) on GNOME 50.1
✅ Tested locally on Ubuntu 26.04 LTS.
<img width="433" height="254" alt="tests" src="https://github.com/user-attachments/assets/4ed675f7-304a-4961-8a97-9df209570cae" />
